### PR TITLE
Update main.php

### DIFF
--- a/application/language/fr/main.php
+++ b/application/language/fr/main.php
@@ -83,8 +83,8 @@ $lang["pp_money_other_information_subscription"] = "Je m'abonne aux compte-rendu
 
 $lang["pp_money_i_certify_content"] = "Je certifie sur l'honneur que <span class=\"error\">*</span> :
 <ul>
-<li>je suis une personne physique et le règlement de ma cotisation ne provient pas du compte d'une personne morale (société, association, collectivité...),</li>
-<li>le paiement de ma cotisation provient de mon compte bancaire personnel ou de celui de mon conjoint, concubin, ascendant ou descendant.</li>
+<li>je suis une personne physique et le règlement de ma cotisation et/ou de mon don ne provient pas du compte d'une personne morale (société, association, collectivité...),</li>
+<li>le paiement de ma cotisation et/ou de mon don provient de mon compte bancaire personnel ou de celui de mon conjoint, concubin, ascendant ou descendant.</li>
 <li>j'ai bien lu les mentions \"à savoir\" ci-dessous</li>
 </ul>";
 


### PR DESCRIPTION
Ajout pour inclure la notion de don à celle de cotisation dans la déclaration sur l'honneur qui est commune aux deux pages (adh, don) car sur https://don.partipirate.org/donate.php il n'est nullement question de cotisation, c'est un non-sens.
